### PR TITLE
feat(images): implement date delete

### DIFF
--- a/pkg/github/user_packages.go
+++ b/pkg/github/user_packages.go
@@ -51,6 +51,7 @@ func (gh *GithubClient) DeleteContainerPackageVersion(ctx context.Context, conta
 	if dryRun {
 		log.Infof("%d", pkg.GetID())
 		log.Infof("%s", pkg.GetName())
+		log.Infof("%s", pkg.GetMetadata().GetContainer().Tags)
 	} else {
 		resp, err := gh.client.Users.PackageDeleteVersion(ctx, gh.username, "container", container, pkg.GetID())
 		if err != nil {


### PR DESCRIPTION
Implements pruning images `N` days old. Also outputs the tags in dry run mode so its easier to know what will be deleted.